### PR TITLE
PRA-53: Server Side Rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ package-lock.json
 yarn.lock
 lerna-debug.log
 .DS_Store
+ssr-dist

--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -19,10 +19,10 @@
       @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap');
     </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{TODO: Set title :) }</title>
+    <title>Cat Love Letter</title>
   </head>
   <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <div id="root"><!--ssr-outlet--></div>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build && tsc --project tsconfig.sw.json",
+    "build": "tsc && vite build --config vite.config.ts && tsc --project tsconfig.sw.json",
+    "build:ssr": "tsc && vite build --config ssr.config.ts && tsc --project tsconfig.sw.json",
     "preview": "vite preview",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/packages/client/src/layout/header/styles.less
+++ b/packages/client/src/layout/header/styles.less
@@ -1,4 +1,5 @@
 @import '../../assets/base/variables.less';
+@import '../../assets/theme/base/base.variables.less';
 
 .page-links {
   display: flex;

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -11,7 +11,8 @@ import App from './App'
 import './assets/styles.less'
 import { startServiceWorker } from './startServiceWorker'
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+ReactDOM.hydrateRoot(
+  document.getElementById('root') as HTMLElement,
   <StrictMode>
     <ErrorBoundary>
       <StyledEngineProvider injectFirst>

--- a/packages/client/src/pages/game/styles.less
+++ b/packages/client/src/pages/game/styles.less
@@ -1,3 +1,5 @@
+@import '../../assets/theme/base/base.variables.less';
+
 .game-page {
   display: flex;
   height: 100%;

--- a/packages/client/ssr.config.ts
+++ b/packages/client/ssr.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import * as path from 'path';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, "ssr.tsx"),
+      name: 'Client',
+      formats: ['cjs'],
+    },
+    rollupOptions: {
+      output: {
+        dir: 'ssr-dist',
+      },
+    }
+  }
+});

--- a/packages/client/ssr.tsx
+++ b/packages/client/ssr.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import App from './src/App';
+import { renderToString } from 'react-dom/server';
+
+export function render() {
+  return renderToString(
+    <App />
+  )
+};

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     port: Number(process.env.CLIENT_PORT) || 3000,
   },
   define: {
-    __SERVER_PORT__: process.env.SERVER_PORT,
+    __SERVER_PORT__: process.env.SERVER_PORT || 3001,
   },
   plugins: [react()],
   css: {

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -3,12 +3,12 @@ import cors from 'cors'
 import { createServer as createViteServer } from 'vite'
 import type { ViteDevServer } from 'vite'
 
-dotenv.config()
-
 import express from 'express'
 
 import * as fs from 'fs'
 import * as path from 'path'
+
+dotenv.config()
 
 const isDev = () => process.env.NODE_ENV === 'development'
 
@@ -17,7 +17,7 @@ async function startServer() {
   app.use(cors())
   const port = Number(process.env.SERVER_PORT) || 3001
 
-  let vite: ViteDevServer | undefined;
+  let vite: ViteDevServer | undefined
   const distPath = path.dirname(require.resolve('client/dist/index.html'))
   const srcPath = path.dirname(require.resolve('client'))
   const ssrClientPath = require.resolve('client/ssr-dist/client.cjs')

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -47,20 +47,14 @@ async function startServer() {
     try {
       let template: string;
 
-      if (!isDev()) {
-        template = fs.readFileSync(
-          path.resolve(distPath, 'index.html'),
-          'utf-8',
-        )
-      } else {
-        template = fs.readFileSync(
-          path.resolve(srcPath, 'index.html'),
-          'utf-8',
-        )
+      const templatePath = isDev() ? srcPath : distPath;
 
-        template = await vite!.transformIndexHtml(url, template)
+      template = fs.readFileSync(
+        path.resolve(templatePath, 'index.html'),
+        'utf-8',
+      )
 
-      }
+      if (isDev()) template = await vite!.transformIndexHtml(url, template)
 
       let render: () => Promise<string>;
 

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -1,20 +1,90 @@
 import dotenv from 'dotenv'
 import cors from 'cors'
+import { createServer as createViteServer } from 'vite'
+import type { ViteDevServer } from 'vite'
+
 dotenv.config()
 
 import express from 'express'
-import { createClientAndConnect } from './db'
 
-const app = express()
-app.use(cors())
-const port = Number(process.env.SERVER_PORT) || 3001
+import * as fs from 'fs'
+import * as path from 'path'
 
-createClientAndConnect()
+const isDev = () => process.env.NODE_ENV === 'development'
 
-app.get('/', (_, res) => {
-  res.json('👋 Howdy from the server :)')
-})
+async function startServer() {
+  const app = express()
+  app.use(cors())
+  const port = Number(process.env.SERVER_PORT) || 3001
 
-app.listen(port, () => {
-  console.log(`  ➜ 🎸 Server is listening on port: ${port}`)
-})
+  let vite: ViteDevServer | undefined;
+  const distPath = path.dirname(require.resolve('client/dist/index.html'))
+  const srcPath = path.dirname(require.resolve('client'))
+  const ssrClientPath = require.resolve('client/ssr-dist/client.cjs')
+
+  if (isDev()) {
+    vite = await createViteServer({
+      server: { middlewareMode: true },
+      root: srcPath,
+      appType: 'custom'
+    })
+
+    app.use(vite.middlewares)
+  }
+
+  app.get('/api', (_, res) => {
+    res.json('👋 Howdy from the server :)')
+  })
+
+
+  if (!isDev()) {
+    app.use('/assets', express.static(path.resolve(distPath, 'assets')))
+  }
+
+  app.use('*', async (req, res, next) => {
+    const url = req.originalUrl;
+
+    try {
+      let template: string;
+
+      if (!isDev()) {
+        template = fs.readFileSync(
+          path.resolve(distPath, 'index.html'),
+          'utf-8',
+        )
+      } else {
+        template = fs.readFileSync(
+          path.resolve(srcPath, 'index.html'),
+          'utf-8',
+        )
+
+        template = await vite!.transformIndexHtml(url, template)
+
+      }
+
+      let render: () => Promise<string>;
+
+      if (!isDev()) {
+        render = (await import(ssrClientPath)).render;
+      } else {
+        render = (await vite!.ssrLoadModule(path.resolve(srcPath, 'ssr.tsx'))).render;
+      }
+
+      const appHtml = await render()
+      const html = template.replace(`<!--ssr-outlet-->`, appHtml)
+
+      res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
+    } catch (e) {
+      if (isDev()) {
+        vite!.ssrFixStacktrace(e as Error)
+      }
+      next(e)
+    }
+  });
+
+  app.listen(port, () => {
+    console.log(`  ➜ 🎸 Server is listening on port: ${port}`)
+  })
+}
+
+startServer();

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "build": "tsc --p ./tsconfig.prod.json",
+    "build": "rm -rf dist && tsc --p ./tsconfig.prod.json",
     "preview": "node ./dist/index.js",
     "dev": "cross-env NODE_ENV=development nodemon index.ts",
     "lint": "eslint .",
@@ -23,6 +23,7 @@
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/jest": "^28.1.8",
+    "@types/node": "^18.11.17",
     "@types/pg": "^8.6.5",
     "@typescript-eslint/eslint-plugin": "^5.35.1",
     "@typescript-eslint/parser": "^5.35.1",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -14,11 +14,9 @@
     "noImplicitReturns": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
-    "noUnusedParameters": true,
-    "noUnusedLocals": true,
     "forceConsistentCasingInFileNames": true,
     "importsNotUsedAsValues": "error",
-    "lib": ["es2019", "esnext.asynciterable"],
+    "lib": ["DOM", "es2019", "esnext.asynciterable"],
     "types": ["node", "jest"],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
### Настроить Express для Server Side Rendering (без Redux, просто отдавать React-страничку)

Все собирается на серверном порту без ошибок
![image](https://github.com/MariaShamonova/practicum-game/assets/86557654/da502daf-d189-4bd4-afd6-b3db2768b92b)

Чтобы запустить ssr локально, нужно:
- закомментировать в `app.tsx`, `main.tsx` и компонентах, которые будут рендерится, все, что связано с редаксом или роутером
- собрать клиентскую часть (`yarn build`, `yarn build:ssr`), находясь в папке `client` (`cd packages/client`)
- создать ссылку на клиентскую часть (`yarn link`)
- перейти в папку server (`cd packages/server`), прилинковать клиентскую часть (`yarn link "client"`)
- собрать и запустить сервер (`yarn build`, `node dist/index.js`)

p.s. если что-то не собирается, напишите мне, будем разбираться :)
p.s.s. а вообще делала по примеру, который показывал Егор Бережной на [вебинаре](https://www.youtube.com/watch?app=desktop&v=alHKbgJnnXw&feature=youtu.be)